### PR TITLE
Use primary instead of localhost address

### DIFF
--- a/cmd/simple-go-service/main.go
+++ b/cmd/simple-go-service/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	logrus.Info("preparing httpServer...")
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf("localhost:8080"),
+		Addr:    fmt.Sprintf("0.0.0.0:8080"),
 		Handler: handler,
 	}
 	go func() {


### PR DESCRIPTION
Receiving this errors from Kubernetes when the app is deployed and probes are created.
```
 Warning  Unhealthy  7s (x3 over 17s)  kubelet            Liveness probe failed: Get "http://10.244.0.39:8080/v1/data": dial tcp 10.244.0.39:8080: connect: connection refused
 Warning  Unhealthy  7s (x4 over 17s)  kubelet            Readiness probe failed: Get "http://10.244.0.39:8080/v1/data": dial tcp 10.244.0.39:8080: connect: connection refused
```
The app is responding from within the pod.

```
kubectl -n simple-go-service port-forward service/simple-go-service 9090:8080
curl --header 'If-Modified-Since: Tue, 24 Sep 2024 10:10:24 GMT'  localhost:9090/v1/data
{"success":{"message":"OK"}}
```